### PR TITLE
Support firing .end() event.

### DIFF
--- a/gulp-blanket.js
+++ b/gulp-blanket.js
@@ -11,12 +11,14 @@ var Duplex = require('stream').Duplex;
 module.exports = function (options) {
     var Mocha = mochaRequire('mocha');
     var duplex = new Duplex({objectMode: true});
+    var stream;
 
     blanket({
         pattern : options.instrument,
         debug: true
     });
     duplex._write = function (file, encoding, done) {
+        stream = this;
         var cover = new Mocha(options);
         delete require.cache[require.resolve(path.resolve(file.path))];
         cover.addFile(file.path);
@@ -50,7 +52,7 @@ module.exports = function (options) {
     };
 
     duplex.on('finish', function () {
-        return;
+      stream.emit('end');
     });
 
     duplex._read = function () {};


### PR DESCRIPTION
The End event lets us know when to call Done from within a gulp task.

This change enables the writing of tasks like so:

```
// generate report.html
gulp.task('test-with-htmlcov', function(done) {
  blanketConfig.captureFile = 'report.html';
  blanketConfig.reporter = 'html-cov';
  gulp
    .src('test/*.js', { read: false })
    .pipe(blanket(blanketConfig))
    .on('end', done);
});

// open report.html in browser
gulp.task('htmlcoverage', ['test-with-htmlcov'], function() {
  gulp
    .src('report.html')
    .pipe(open());
});
```
